### PR TITLE
Upgrade to v0.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - python
     - hatchling
     - hatch-vcs >=0.3
-    - setuptools-scm >=7.1
     - pip
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,14 @@ requirements:
     - pip
   run:
     - python
-    - anaconda-cli-base
-    - anaconda-cloud-auth
+    - anaconda-cli-base >=0.2
+    - anaconda-cloud-auth >=0.3
+    - anaconda-client >=1.12.2
 
 test:
   imports:
     - anaconda_cloud_cli
+    - binstar_client
   commands:
     - python -c "from anaconda_cloud_cli import __version__; assert __version__ == \"{{ version }}\""
     #- pip check # anaconda-anon-usage 0.4.3 requires conda, which is not installed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "anaconda-cloud-cli" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/anaconda_cloud_cli-{{ version }}.tar.gz
-  sha256: 19ac6d90ac85e41314258bf607d96b6d7d999be82de67ae359c1f7055b29c765
+  sha256: 62f897a83641340599c908874b0a31903ff79881d693ddbaade2905f526ac231
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
{package} {version} {:snowflake:}

**Destination channel:** defaults

### Links

- [TULZ-930](https://anaconda.atlassian.net/browse/TULZ-930) 
- [Upstream repository](https://github.com/anaconda/anaconda-cloud-tools)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-cloud-tools/releases/tag/anaconda-cloud-cli-v0.2.0)

### Explanation of changes:

- Adds `anaconda-client >=1.12.2` and a few other minimal pins
- This fixes some import errors due to the removal of `clyent` dependency in `anaconda-client`.


[TULZ-930]: https://anaconda.atlassian.net/browse/TULZ-930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ