### PR TITLE
anaconda-cloud-cli 0.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,36 @@
 {% set name = "anaconda-cloud-cli" %}
-{% set version = "0.2.0" %}
+{% set snake_name = name | replace("-", "_") %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/anaconda_cloud_cli-{{ version }}.tar.gz
-  sha256: 62f897a83641340599c908874b0a31903ff79881d693ddbaade2905f526ac231
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ snake_name }}-{{ version }}.tar.gz
+  sha256: b72b3008ea3b57f11dbe5535db9c016f594ac378fb15dea3b52874ad279fcd62
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python
-    - hatchling
+    - hatchling >=1.20.0
     - hatch-vcs >=0.3
     - setuptools-scm >=7.1
     - pip
   run:
     - python
-    - anaconda-cli-base >=0.2
-    - anaconda-cloud-auth >=0.3
-    - anaconda-client >=1.12.2
 
 test:
-  imports:
-    - anaconda_cloud_cli
-    - binstar_client
-  commands:
-    - python -c "from anaconda_cloud_cli import __version__; assert __version__ == \"{{ version }}\""
-    #- pip check # anaconda-anon-usage 0.4.3 requires conda, which is not installed.
+  # No imports because it's an empty package
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   summary: The Anaconda Cloud CLI
@@ -44,7 +40,7 @@ about:
   license_file: LICENSE
   license_family: BSD
   doc_url: https://pypi.org/project/anaconda-cloud-cli/
-  dev_url: https://pypi.org/project/anaconda-cloud-cli/
+  dev_url: https://github.com/anaconda/anaconda-cloud-tools/tree/main/libs/anaconda-cloud-cli
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
     - pip
   commands:
     - pip check
+    - python -c "from importlib.util import find_spec; assert not bool(find_spec(\"anaconda_cloud_cli\"))"
 
 about:
   summary: The Anaconda Cloud CLI


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6150](https://anaconda.atlassian.net/browse/PKG-6150) 
- [Upstream repository](https://github.com/anaconda/anaconda-cloud-tools/tree/anaconda-cloud-cli-v0.3.0/libs/anaconda-cloud-cli)
- Requirements: https://inspector.pypi.io/project/anaconda-cloud-cli/0.3.0/packages/dd/9a/af1a664f99028ba0a5d575f162ba500e71b96c19007d5213cf86b6f00702/anaconda_cloud_cli-0.3.0.tar.gz/anaconda_cloud_cli-0.3.0/pyproject.toml

### Explanation of changes:

- Remove runtime dependencies.
- Remove imports. It's an empty package, and it's needed to override a legacy one, which will only be installed if an upgrade gets triggered and is there to allow their environments not to break.
- Add pip check
- Add a test command to verify `find_spec`
- Update dev_url



[PKG-6150]: https://anaconda.atlassian.net/browse/PKG-6150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ